### PR TITLE
Fix unportable test(1) operator.

### DIFF
--- a/eg/sh_script
+++ b/eg/sh_script
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$SPACETRACK_USER" == "" ]
+if [ "$SPACETRACK_USER" = "" ]
 then
     echo "
 You must set environment variable SPACETRACK_USER to your Spacetrack


### PR DESCRIPTION
'==' is only supported by bash, not even by GNU coreutils; POSIX defines '=' as comparison operator.